### PR TITLE
Add asterisk support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 
 export default range => {
   // Test `Range` format.
-  if (range.match(/^\w+=\d+-\d+$/) === null) {
+  if (range.match(/^\w+=\d+-(?:\*|\d+)$/) === null) {
     return -2;
   }
 
@@ -14,8 +14,8 @@ export default range => {
 
   // Pick `first-byte-pos` and `last-byte-pos` from `range-set`.
   const first = parseInt(rangeSet[0], 10);
-  const last = parseInt(rangeSet[1], 10);
-  const unit = range.replace(range.match(/\=\d+-\d+$/), '');
+  const last = parseInt(rangeSet[1], 10) || rangeSet[1];
+  const unit = range.replace(range.match(/\=.+$/), '');
 
   // `first-byte-pos` must not be greater than `last-byte-pos`.
   if (first > last) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -30,10 +30,18 @@ describe('RangeSpecifierParser', () => {
     parser('bytes=5-0').should.equal(-1);
   });
 
-  it('should parse range', () => {
+  it('should parse a numeric range', () => {
     const range = parser('bytes=0-499');
 
     range.last.should.equal(499);
+    range.first.should.equal(0);
+    range.unit.should.equal('bytes');
+  });
+
+  it('should parse a range with asterisk', () => {
+    const range = parser('bytes=0-*');
+
+    range.last.should.equal('*');
     range.first.should.equal(0);
     range.unit.should.equal('bytes');
   });


### PR DESCRIPTION
Adds support for the last argument of the range to be an "asterisk". This will allow dependees to specify an infinite range, as per RFC7233.

Depends on #2.