### PR TITLE
Fix parsing of falsy range

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ export default range => {
 
   // Pick `first-byte-pos` and `last-byte-pos` from `range-set`.
   const first = parseInt(rangeSet[0], 10);
-  const last = parseInt(rangeSet[1], 10) || rangeSet[1];
+  const last = isFinite(rangeSet[1]) ? parseInt(rangeSet[1], 10) : rangeSet[1];
   const unit = range.replace(range.match(/\=.+$/), '');
 
   // `first-byte-pos` must not be greater than `last-byte-pos`.

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -30,6 +30,14 @@ describe('RangeSpecifierParser', () => {
     parser('bytes=5-0').should.equal(-1);
   });
 
+  it('should accept `0-0` as a valid range', () => {
+    const range = parser('bytes=0-0');
+
+    range.last.should.equal(0);
+    range.first.should.equal(0);
+    range.unit.should.equal('bytes');
+  });
+
   it('should parse a numeric range', () => {
     const range = parser('bytes=0-499');
 


### PR DESCRIPTION
Fixes an issue where the range `items=0-0` would be parsed as:

```js
{ first: 0, last: '0', unit: 'bytes' }
```

Note the string around zero — `'0'`.

This was occurring because `0` was parsed as an integer, which is _falsy_ in Javascript.